### PR TITLE
Prevented negative scrolling

### DIFF
--- a/src/directives/parallax.js
+++ b/src/directives/parallax.js
@@ -89,6 +89,9 @@ directive('duParallax',
             }
           }
 
+          //Prevent negative scrolling
+          properties.y = (properties.y >= 0) ? properties.y : 0;
+
           //Detect changes, if no changes avoid reflow
           var hasChange = angular.isUndefined(currentProperties);
           if(!hasChange) {


### PR DESCRIPTION
On browsers with rubber-band scrolling, scrolling beyond the top of the
document leads to undesirable displacement of the image. This fix
prevents scrolling beyond the bounds of the document.
